### PR TITLE
Make examples in docs compatible with Django migrations

### DIFF
--- a/simpleimages/utils.py
+++ b/simpleimages/utils.py
@@ -41,7 +41,6 @@ def perform_transformation(instance, field_names_to_transform=None):
         if field_names_to_transform is None or source_field_name in field_names_to_transform:
             for destination_field_name, transformation in destination_dict.items():
                 arguments = [instance, source_field_name, destination_field_name, transformation]
-                print(get_caller(), instance)
                 get_caller()(transform_field, *arguments)
 
 


### PR DESCRIPTION
Closes #26 
