### PR TITLE
update requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ setup(
     description='Opinionated Django image transforms on models',
     long_description=open('README.rst').read(),
     install_requires=[
-        "Django>=1.5,<1.10",
+        "Django>=1.5,<1.12",
         "six",
         "Pillow",
         'clint',
-        'dill',
+        'dill>0.2.8',
     ],
     zip_safe=False,  # so that django finds management commands,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "six",
         "Pillow",
         'clint',
-        'dill>0.2.8',
+        'dill<0.2.8',
     ],
     zip_safe=False,  # so that django finds management commands,
     classifiers=[


### PR DESCRIPTION
Dill has a backwards incomparable change in 2.8 which breaks this project. Fixing the requirements to 2.7 keeps the project working.
Django 1.11 branch works fine.  Updated it's requirements.